### PR TITLE
hyperopt 0.2.7

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,3 @@
-
-aggregate_check: false
-
 #upload_channels:
 #  - sfe1ed40
 #channels:

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,11 @@
+
+aggregate_check: false
+
+#upload_channels:
+#  - sfe1ed40
+#channels:
+#  - sfe1ed40
+#channel_targets:
+#  - sfe1ed40
+#build_parameters:
+#  - ""

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,7 @@
-#upload_channels:
-#  - sfe1ed40
-#channels:
-#  - sfe1ed40
+upload_channels:
+  - sfe1ed40
+channels:
+  - sfe1ed40
 #channel_targets:
 #  - sfe1ed40
 #build_parameters:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,35 +10,44 @@ source:
   sha256: 1bf89ae58050bbd32c7307199046117feee245c2fd9ab6255c7308522b7ca149
 
 build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
   entry_points:
     - hyperopt-mongo-worker=hyperopt.mongoexp:main
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
-  number: 0
 
 requirements:
   host:
+    - python
+    - numpy
     - pip
-    - python >=3.6
+    - setuptools
+    - wheel
   run:
+    - python
     - cloudpickle
     - future
     - networkx >=2.2
+    # see numpy pinnings https://github.com/conda-forge/hyperopt-feedstock/pull/11/commits/349d44f2aacf045fbef322d0a4d3e7a4a3eab456
     - numpy >=1.17
     - py4j
-    - python >=3.6
     - scipy
     - six
     - tqdm
+  run_constrained:
+    - pymongo
+    - pyspark
+    - lightgbm
+    - scikit-learn
 
 test:
   imports:
     - hyperopt
+    - hyperopt.pyll
+  requires:
+    - pip
   commands:
     - pip check
     - hyperopt-mongo-worker --help
-  requires:
-    - pip
 
 about:
   home: https://github.com/hyperopt/hyperopt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,7 +58,7 @@ about:
   description: |
     Hyperopt is a Python library for serial and parallel optimization over awkward search spaces,
     which may include real-valued, discrete, and conditional dimensions.
-  doc_url: http://hyperopt.github.io/hyperopt/
+  doc_url: https://hyperopt.github.io/hyperopt/
   dev_url: https://github.com/hyperopt/hyperopt
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,3 +1,4 @@
+# this package is not intended to go on the default channel
 {% set name = "hyperopt" %}
 {% set version = "0.2.7" %}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ build:
 requirements:
   host:
     - python
-    - numpy ={{ numpy }}
+    - numpy {{ numpy }}
     - pip
     - setuptools
     - wheel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ build:
 requirements:
   host:
     - python
-    - numpy
+    - numpy ={{ numpy }}
     - pip
     - setuptools
     - wheel


### PR DESCRIPTION
License: https://github.com/hyperopt/hyperopt/blob/0.2.7/LICENSE.txt
Changelog: https://github.com/hyperopt/hyperopt/tags
Requiements:
- https://github.com/hyperopt/hyperopt/blob/0.2.7/setup.py
- http://hyperopt.github.io/hyperopt/setup/installation-notes/

Actions:
1. Add abs.yaml (disabled channels before merging)
2. Add --no-deps
3. Add numpy, setuptools, and wheel to host
4. Add `run_constrained`: pymongo, pyspark, lightgbm, scikit-learn
5. Add hyperopt.pyll to test/imports