### PR TITLE
Rebuild 0.2.7 for Python 3.11

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 1bf89ae58050bbd32c7307199046117feee245c2fd9ab6255c7308522b7ca149
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps
   entry_points:
     - hyperopt-mongo-worker=hyperopt.mongoexp:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 1
-  script: {{ PYTHON }} -m pip install . -vv --no-deps
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - hyperopt-mongo-worker=hyperopt.mongoexp:main
 


### PR DESCRIPTION
[Upstream repo](https://github.com/hyperopt/hyperopt)

No changes aside from adding `--no-build-isolation`